### PR TITLE
🤖 Update `.dockerignore` file

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -4,3 +4,4 @@
 tests/
 .appends
 .gitignore
+.gitattributes

--- a/.dockerignore
+++ b/.dockerignore
@@ -2,3 +2,4 @@
 .github/
 .stack-work/
 tests/
+.appends

--- a/.dockerignore
+++ b/.dockerignore
@@ -3,3 +3,4 @@
 .stack-work/
 tests/
 .appends
+.gitignore

--- a/.dockerignore
+++ b/.dockerignore
@@ -5,3 +5,4 @@ tests/
 .appends
 .gitignore
 .gitattributes
+.dockerignore

--- a/.dockerignore
+++ b/.dockerignore
@@ -6,3 +6,4 @@ tests/
 .gitignore
 .gitattributes
 .dockerignore
+Dockerfile


### PR DESCRIPTION
To help both speedup Docker builds _and_ prevent new containers being created when unrelated files changes, this PR adds some rules to the `.dockerignore` file (or add the file when it didn't exist).
See https://docs.docker.com/engine/reference/builder/#dockerignore-file for more information on `.dockerignore` files and what they do.

# Tracking issue

See https://github.com/exercism/exercism/issues/6113
