### PR TITLE
Add common dependencies

### DIFF
--- a/pre-compiled/package.yaml
+++ b/pre-compiled/package.yaml
@@ -8,9 +8,14 @@ library:
   exposed-modules: LeapYear
   source-dirs: src
   ghc-options: -Wall
-  # dependencies:
-  # - foo       # List here the packages you
-  # - bar       # want to use in your solution.
+  dependencies:
+    - QuickCheck
+    - lens
+    - parallel
+    - vector
+    - split
+    - random
+    - string-conversions
 
 tests:
   test:


### PR DESCRIPTION
This PR pre-loads the following dependencies:

- QuickCheck
- lens
- parallel
- vector
- split
- random
- string-conversions

See https://github.com/exercism/haskell/issues/1006
