### PR TITLE
Pre-load `attoparsec` and `megaparsec` dependencies

### DIFF
--- a/pre-compiled/package.yaml
+++ b/pre-compiled/package.yaml
@@ -17,6 +17,8 @@ library:
     - random
     - string-conversions
     - text
+    - attoparsec
+    - megaparsec
 
 tests:
   test:


### PR DESCRIPTION
This is a small PR to add `attoparsec` and `megaparsec` to the pre-compiled dependencies, following a discussion in issue [#1044](https://github.com/exercism/haskell/issues/1044). 

I've verified that the resulting image is able to run the two variations of the wordy problem I had attempted previously.

Please let me know if I should update anything besides `pre-compiled/package.yaml`, and I'll be happy to do so. It's my first contribution here, so I'm likely to have missed something. 