### PR TITLE
Add regex-tdfa to preloaded packages

### DIFF
--- a/pre-compiled/package.yaml
+++ b/pre-compiled/package.yaml
@@ -20,6 +20,7 @@ library:
     - attoparsec
     - megaparsec
     - multiset
+    - regex-tdfa
 
 tests:
   test:


### PR DESCRIPTION
regex-tdfa is a fairly common package, and other tracks do allow for use of regex, so it's not philosophically banned either. It is very useful for several exercises.