### PR TITLE
Add @exercism/haskell as codeowner for `pre-compiled/package.yaml` file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,2 @@
 * @exercism/maintainers-admin
+pre-compiled/package.yaml @exercism/haskell @exercism/maintainers-admin


### PR DESCRIPTION
Closes https://github.com/exercism/haskell-test-runner/issues/53
