### PR TITLE
Optimize the CI workflow by pre-building and caching the docker image

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,5 +16,20 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b
 
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@8c0edbc76e98fa90f69d9a2c020dcb50019dc325
+        with:
+          install: true
+
+      - name: Build and push
+        uses: docker/build-push-action@c56af957549030174b10d6867f20e78cfd7debc5
+        with:
+          context: .
+          push: false
+          load: true
+          tags: exercism/haskell-test-runner
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
       - name: Run Tests in Docker
         run: bin/run-tests-in-docker.sh

--- a/bin/run-in-docker.sh
+++ b/bin/run-in-docker.sh
@@ -31,7 +31,7 @@ output_dir="${3%/}"
 mkdir -p "${output_dir}"
 
 # Build the Docker image
-docker build --rm -t exercism/test-runner .
+docker build --rm -t exercism/haskell-test-runner .
 
 # Run the Docker image using the settings mimicking the production environment
 # TODO: --read-only
@@ -41,4 +41,4 @@ docker run \
     --mount type=bind,src="${input_dir}",dst=/solution \
     --mount type=bind,src="${output_dir}",dst=/output \
     --mount type=tmpfs,dst=/tmp \
-    exercism/test-runner "${slug}" /solution /output 
+    exercism/haskell-test-runner "${slug}" /solution /output 

--- a/bin/run-tests-in-docker.sh
+++ b/bin/run-tests-in-docker.sh
@@ -14,7 +14,7 @@ set -e
 # ./bin/run-tests-in-docker.sh
 
 # Build the Docker image
-docker build --rm -t exercism/test-runner .
+docker build --rm -t exercism/haskell-test-runner .
 
 # Run the Docker image using the settings mimicking the production environment
 # TODO: --read-only
@@ -25,4 +25,4 @@ docker run \
     --mount type=tmpfs,dst=/tmp \
     --workdir /opt/test-runner \
     --entrypoint /opt/test-runner/bin/run-tests.sh \
-    exercism/test-runner
+    exercism/haskell-test-runner


### PR DESCRIPTION
Before the tests are run in docker, we pre-build the docker image using buildx and the build-push action.
As the build-push action supports caching, when the docker images is built again as part of the `bin/run-tests-in-docker.sh` script, the cached layers are used.

This is especially useful for this test runner, as it takes quite a while to build.
