### PR TITLE
Allow using the `safe` package

### DIFF
--- a/pre-compiled/package.yaml
+++ b/pre-compiled/package.yaml
@@ -22,6 +22,7 @@ library:
     - multiset
     - regex-tdfa
     - extra
+    - safe
 
 tests:
   test:


### PR DESCRIPTION
The `safe` package is of similar utility as `extra`: it provides functions that arguably are 'missing' from the standard library.