### PR TITLE
Allow using the `stm` package

### DIFF
--- a/pre-compiled/package.yaml
+++ b/pre-compiled/package.yaml
@@ -23,6 +23,7 @@ library:
     - regex-tdfa
     - extra
     - safe
+    - stm
 
 tests:
   test:


### PR DESCRIPTION
[`stm`](https://hackage.haskell.org/package/stm) is commonly used for concurrency. Indeed, it is recommended by the [Bank Account](https://exercism.org/tracks/haskell/exercises/bank-account) exercise and [used in its example solution](https://github.com/exercism/haskell/blob/ca46035dd80a8c1948a6bcfb170ba4182c8dad1d/exercises/practice/bank-account/.meta/examples/success-standard/package.yaml#L10).