### PR TITLE
Run scripts fail on errors

### DIFF
--- a/bin/run-tests.sh
+++ b/bin/run-tests.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env sh
+#!/usr/bin/env bash
 
 # Synopsis:
 # Test the test runner by running it against a predefined set of solutions 
@@ -10,6 +10,8 @@
 
 # Example:
 # ./bin/run-tests.sh
+
+set -euo pipefail
 
 exit_code=0
 
@@ -30,12 +32,20 @@ for test_dir in tests/*; do
       -e "s~${test_dir_path}~/solution~g" \
       "${results_file_path}"
 
+    # disable -e since we want all diffs even if one has unexpected
+    # results
+    old_opts=$-
+    set +e
+
     echo "${test_dir_name}: comparing results.json to expected_results.json"
     diff "${results_file_path}" "${expected_results_file_path}"
 
     if [ $? -ne 0 ]; then
         exit_code=1
     fi
+
+    # re-enable original options
+    set -$old_opts
 done
 
 exit ${exit_code}

--- a/bin/run.sh
+++ b/bin/run.sh
@@ -15,6 +15,8 @@
 # Example:
 # ./bin/run.sh two-fer /absolute/path/to/two-fer/solution/folder/ /absolute/path/to/output/directory/
 
+set -euo pipefail
+
 # If any required arguments is missing, print the usage and exit
 if [ -z "$1" ] || [ -z "$2" ] || [ -z "$3" ]; then
     echo "usage: ./bin/run.sh exercise-slug /absolute/path/to/two-fer/solution/folder/ /absolute/path/to/output/directory/"
@@ -33,10 +35,17 @@ echo "${slug}: testing..."
 
 pushd "${input_dir}" > /dev/null
 
+# disable -e since we expect some tests to fail
+old_opts=$-
+set +e
+
 # Run the tests for the provided implementation file and redirect stdout and
 # stderr to capture it
 test_output=$(stack build --resolver lts-19.27 --test --allow-different-user 2>&1)
 exit_code=$?
+
+# re-enable original options
+set -$old_opts
 
 popd
 


### PR DESCRIPTION
Switches from `sh` to `bash` for the `run-tests` script since on Ubunto, `sh` is `dash` which doesn't have `pipefail`. Allows the commands `stack test` and `diff` to return a non-zero exit code, since this is expected during normal runs; any other failures will immediate fail the script.

To debug unexpected failures, `set -x` is also useful. We could consider setting this on CI.