### PR TITLE
Look for test name to task id mapping in manifest

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ results.json
 stack.yaml.lock
 bin/setup-tests
 tests/**/HspecFormatter.hs
+**/dist-newstyle/

--- a/pre-compiled/test/Manifest.hs
+++ b/pre-compiled/test/Manifest.hs
@@ -1,0 +1,37 @@
+{-# language OverloadedStrings #-}
+module Manifest ( Manifest, getTaskId, getManifest ) where
+
+import Data.Aeson ( FromJSON (parseJSON), (.:))
+import qualified Data.Aeson as Aeson
+import Data.Map (Map)
+import qualified Data.Map as Map
+import Data.Text (Text)
+import qualified Data.Text as Text
+import System.Directory
+import System.FilePath ((</>))
+
+newtype Test = Test
+  { taskId :: Maybe Int
+  }
+
+instance FromJSON Test where
+  parseJSON = Aeson.withObject "test" $ \v -> Test <$> v .: "task_id"
+
+newtype Manifest = Manifest
+  { _tests :: Map Text Test
+  }
+
+instance FromJSON Manifest where
+  parseJSON = Aeson.withObject "manifest" $ \v -> Manifest <$> v .: "tests"
+
+-- | Map test description to task ID based on a manifest.
+getTaskId :: Manifest -> String -> Maybe Int
+getTaskId (Manifest m) name = Map.lookup (Text.pack name) m >>= taskId
+
+findManifest :: IO FilePath
+findManifest = do
+  d <- getCurrentDirectory
+  pure $ d </> ".exercism/metadata.json"
+
+getManifest :: IO (Either String Manifest)
+getManifest = findManifest >>= Aeson.eitherDecodeFileStrict


### PR DESCRIPTION
This is an initial stab at #19. It looks for a name to task id mapping in the projects manifest file `metadata.json`. For instance for `leap` the root object should be amended with an object like this:
```
  "tests": {
    "2015 - year not divisible by 4 in common year": { "task_id": 1 },
    "1970 - year divisible by 2, not divisible by 4 in common year": { "task_id": 1 },
    "1996 - year divisible by 4, not divisible by 100 in leap year": { "task_id": 1 },
    "1960 - year divisible by 4 and 5 is still a leap year": { "task_id": 1 },
    "2100 - year divisible by 100, not divisible by 400 in common year": { "task_id": 1 },
    "1900 - year divisible by 100 but not by 3 is still not a leap year": { "task_id": 1 },
    "2000 - year divisible by 400 in leap year": { "task_id": 1 },
    "2400 - year divisible by 400 but not by 125 is still a leap year": { "task_id": 1 },
    "1800 - year divisible by 200, not divisible by 400 in common year": { "task_id": 1 }
  }
```
Or whatever the task id is supposed to be. This wasn't entirely clear to me.

I've added a module `Manifest.hs` that will look for `metadata.json`. The mechanism used for locating the file simply assumes that the `cwd` is where `.exercism` is located. This might not be the most robust way to do it, but it *is* what the test runner seems to do. So I don't see any immediate benefit to improving this. If `metadata.json` is not located or fails to parse the task IDs are simply set to `null` in the generated report.