### PR TITLE
Look for test name to task id mapping in manifest

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ results.json
 stack.yaml.lock
 bin/setup-tests
 tests/**/HspecFormatter.hs
+**/dist-newstyle/

--- a/bin/run.sh
+++ b/bin/run.sh
@@ -98,6 +98,6 @@ fi
 echo "$stack_yml_file_contents" > "${input_dir}/stack.yaml"
 echo "$package_yml_file_contents" > "${input_dir}/package.yaml"
 echo "$tests_file_contents" > "${input_dir}/test/Tests.hs"
-rm -f "${input_dir}/test/HspecFormatter.hs"
+rm -f "${input_dir}"/test/{HspecFormatter,Manifest}.hs
 
 echo "${slug}: done"

--- a/pre-compiled/package.yaml
+++ b/pre-compiled/package.yaml
@@ -4,10 +4,11 @@ version: 1.6.0.10
 dependencies:
   - base
 
+ghc-options: -Wall
+
 library:
   exposed-modules: LeapYear
   source-dirs: src
-  ghc-options: -Wall
   dependencies:
     - QuickCheck
     - lens
@@ -30,10 +31,14 @@ tests:
     main: Tests.hs
     source-dirs: test
     dependencies:
-      - leap
       - aeson
       - aeson-pretty
       - bytestring
+      - containers
+      - directory
+      - filepath
       - hspec
       - hspec-core
+      - leap
       - stm
+      - text

--- a/pre-compiled/src/LeapYear.hs
+++ b/pre-compiled/src/LeapYear.hs
@@ -1,4 +1,4 @@
 module LeapYear (isLeapYear) where
 
 isLeapYear :: Integer -> Bool
-isLeapYear year = error "You need to implement this function."
+isLeapYear _year = error "You need to implement this function."

--- a/pre-compiled/test/HspecFormatter.hs
+++ b/pre-compiled/test/HspecFormatter.hs
@@ -3,20 +3,20 @@
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE OverloadedRecordDot #-}
 {-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE NamedFieldPuns #-}
+{-# LANGUAGE LambdaCase #-}
 
 module HspecFormatter (formatter) where
 
-import Data.Aeson (ToJSON, toJSON, object, encode, (.=))
+import Data.Aeson (ToJSON, toJSON, object, (.=))
 import Data.Aeson.Encode.Pretty (encodePretty)
 import qualified Data.ByteString.Lazy as BS
-import Data.Maybe (fromMaybe)
-import Control.Monad (forM_)
 import Control.Concurrent.STM
-import GHC.IO.Unsafe (unsafePerformIO)
-import Test.Hspec
 import Test.Hspec.Core.Formatters.V2
-import Test.Hspec.Core.Format (Format, FormatConfig, Path, Event(ItemDone, Done), FailureReason(..))
+import Test.Hspec.Core.Format (Format, FormatConfig, Path, Event(ItemDone, Done))
 import GHC.Generics (Generic)
+import qualified Manifest
+import qualified System.IO as IO
 
 data TestResultStatus = Pass | Fail | Err deriving (Eq, Show)
 
@@ -28,10 +28,17 @@ instance ToJSON TestResultStatus where
 data TestResult = TestResult {
   name :: String,
   status :: TestResultStatus,
-  message :: Maybe String
+  message :: Maybe String,
+  taskId :: Maybe Int
 } deriving (Generic, Show)
 
 instance ToJSON TestResult where
+  toJSON t = object [
+      "name" .= t.name
+      , "status" .= t.status
+      , "message" .= t.message
+      , "task_id" .= t.taskId
+    ]
 
 data TestResults = TestResults {
   resultsStatus :: TestResultStatus,
@@ -48,25 +55,21 @@ instance ToJSON TestResults where
       , "tests" .= t.tests
     ]
 
-results :: TVar TestResults
-{-# NOINLINE results #-}
-results = unsafePerformIO $ newTVarIO (TestResults Fail [] Nothing 2)
-
-format :: Format
-format event = case event of
+format :: TVar TestResults -> (String -> Maybe Int) -> Format
+format results getTaskId event = case event of
   ItemDone path item -> handleItemDone path item
   Done _ -> handleDone
   _ -> return ()
   where
     handleItemDone :: Path -> Item -> IO ()
-    handleItemDone (_, requirement) item =
+    handleItemDone (_, requirement) item = do
+        let taskId = getTaskId requirement
         case itemResult item of
-          Success ->
-            addTestResult TestResult { name = requirement, status = Pass, message = Nothing }
+          Success -> addTestResult TestResult { name = requirement, status = Pass, message = Nothing, taskId }
           -- NOTE: We don't expect pending tests in Exercism exercises
           Pending _ _ -> return ()
           Failure _ failureReason ->
-            let baseResult = TestResult { name = requirement, status = Fail, message = Just "" }
+            let baseResult = TestResult { name = requirement, status = Fail, message = Just "", taskId }
                 result = case failureReason of
                   NoReason -> baseResult { message = Just "No reason" }
                   Reason reason -> baseResult { message = Just reason }
@@ -86,6 +89,11 @@ format event = case event of
       BS.writeFile "results.json" (encodePretty finalResults)
       return ()
 
-
 formatter :: FormatConfig -> IO Format
-formatter _config = return format
+formatter _config = do
+  getTaskId <- Manifest.getManifest >>= \case
+    Left e -> do
+      IO.hPutStrLn IO.stderr e
+      pure $ \_ -> Nothing
+    Right m -> pure $ Manifest.getTaskId m
+  format <$> newTVarIO (TestResults Fail [] Nothing 2) <*> pure getTaskId

--- a/pre-compiled/test/Manifest.hs
+++ b/pre-compiled/test/Manifest.hs
@@ -1,0 +1,45 @@
+{-# language OverloadedStrings #-}
+{-# language LambdaCase #-}
+module Manifest ( Manifest, getTaskId, getManifest ) where
+
+import Data.Aeson ( FromJSON (parseJSON), (.:))
+import qualified Data.Aeson as Aeson
+import Data.Map (Map)
+import qualified Data.Map as Map
+import Data.Text (Text)
+import qualified Data.Text as Text
+import System.Directory
+import System.FilePath ((</>))
+import Text.Printf (printf)
+import Data.Bifunctor (first)
+
+newtype Test = Test
+  { taskId :: Maybe Int
+  }
+
+instance FromJSON Test where
+  parseJSON = Aeson.withObject "test" $ \v -> Test <$> v .: "task_id"
+
+newtype Manifest = Manifest
+  { _tests :: Map Text Test
+  }
+
+instance FromJSON Manifest where
+  parseJSON = Aeson.withObject "manifest" $ \v -> Manifest <$> v .: "tests"
+
+-- | Map test description to task ID based on a manifest.
+getTaskId :: Manifest -> String -> Maybe Int
+getTaskId (Manifest m) name = Map.lookup (Text.pack name) m >>= taskId
+
+findManifest :: IO (Either String FilePath)
+findManifest = do
+  d <- getCurrentDirectory
+  let p = d </> ".exercism/metadata.json"
+  doesFileExist p >>= \case
+    False -> pure $ Left $ printf "Could not find manifest: %s" p
+    True  -> pure $ Right p
+
+getManifest :: IO (Either String Manifest)
+getManifest = findManifest >>= \case
+  Right p -> first (printf "Could not decode manifest: %s") <$> Aeson.eitherDecodeFileStrict p
+  Left e -> pure $ Left e

--- a/tests/example-all-fail/expected_results.json
+++ b/tests/example-all-fail/expected_results.json
@@ -5,47 +5,56 @@
         {
             "message": "Expected 'False' but got 'True'",
             "name": "2015 - year not divisible by 4 in common year",
-            "status": "fail"
+            "status": "fail",
+            "task_id": null
         },
         {
             "message": "Expected 'False' but got 'True'",
             "name": "1970 - year divisible by 2, not divisible by 4 in common year",
-            "status": "fail"
+            "status": "fail",
+            "task_id": null
         },
         {
             "message": "Expected 'True' but got 'False'",
             "name": "1996 - year divisible by 4, not divisible by 100 in leap year",
-            "status": "fail"
+            "status": "fail",
+            "task_id": null
         },
         {
             "message": "Expected 'True' but got 'False'",
             "name": "1960 - year divisible by 4 and 5 is still a leap year",
-            "status": "fail"
+            "status": "fail",
+            "task_id": null
         },
         {
             "message": "Expected 'False' but got 'True'",
             "name": "2100 - year divisible by 100, not divisible by 400 in common year",
-            "status": "fail"
+            "status": "fail",
+            "task_id": null
         },
         {
             "message": "Expected 'False' but got 'True'",
             "name": "1900 - year divisible by 100 but not by 3 is still not a leap year",
-            "status": "fail"
+            "status": "fail",
+            "task_id": null
         },
         {
             "message": "Expected 'True' but got 'False'",
             "name": "2000 - year divisible by 400 in leap year",
-            "status": "fail"
+            "status": "fail",
+            "task_id": null
         },
         {
             "message": "Expected 'True' but got 'False'",
             "name": "2400 - year divisible by 400 but not by 125 is still a leap year",
-            "status": "fail"
+            "status": "fail",
+            "task_id": null
         },
         {
             "message": "Expected 'False' but got 'True'",
             "name": "1800 - year divisible by 200, not divisible by 400 in common year",
-            "status": "fail"
+            "status": "fail",
+            "task_id": null
         }
     ],
     "version": 2

--- a/tests/example-empty-file/expected_results.json
+++ b/tests/example-empty-file/expected_results.json
@@ -1,5 +1,5 @@
 {
   "version": 2,
   "status": "error",
-  "message": "\n/solution/src/LeapYear.hs:1:1: error:\n    File name does not match module name:\n    Saw: ‘Main’\n    Expected: ‘LeapYear’\n\nError: [S-7282]\n       Stack failed to execute the build plan.\n       \n       While executing the build plan, Stack encountered the following errors:\n       \n       [S-7011]\n       While building package leap-1.6.0.10 (scroll up to its section to see the error) using:\n       --verbose=1 build lib:leap test:test --ghc-options \"\"\n       Process exited with code: ExitFailure 1 "
+  "message": "\n/solution/src/LeapYear.hs:1:1: error:\n    File name does not match module name:\n    Saw: ‘Main’\n    Expected: ‘LeapYear’\n\nError: [S-7282]\n       Stack failed to execute the build plan.\n       \n       While executing the build plan, Stack encountered the error:\n       \n       [S-7011]\n       While building package leap-1.6.0.10 (scroll up to its section to see the error) using:\n       --verbose=1 build lib:leap test:test --ghc-options \"\"\n       Process exited with code: ExitFailure 1 "
 }

--- a/tests/example-partial-fail/expected_results.json
+++ b/tests/example-partial-fail/expected_results.json
@@ -5,47 +5,56 @@
         {
             "message": null,
             "name": "2015 - year not divisible by 4 in common year",
-            "status": "pass"
+            "status": "pass",
+            "task_id": null
         },
         {
             "message": null,
             "name": "1970 - year divisible by 2, not divisible by 4 in common year",
-            "status": "pass"
+            "status": "pass",
+            "task_id": null
         },
         {
             "message": null,
             "name": "1996 - year divisible by 4, not divisible by 100 in leap year",
-            "status": "pass"
+            "status": "pass",
+            "task_id": null
         },
         {
             "message": null,
             "name": "1960 - year divisible by 4 and 5 is still a leap year",
-            "status": "pass"
+            "status": "pass",
+            "task_id": null
         },
         {
             "message": null,
             "name": "2100 - year divisible by 100, not divisible by 400 in common year",
-            "status": "pass"
+            "status": "pass",
+            "task_id": null
         },
         {
             "message": null,
             "name": "1900 - year divisible by 100 but not by 3 is still not a leap year",
-            "status": "pass"
+            "status": "pass",
+            "task_id": null
         },
         {
             "message": "Expected 'True' but got 'False'",
             "name": "2000 - year divisible by 400 in leap year",
-            "status": "fail"
+            "status": "fail",
+            "task_id": null
         },
         {
             "message": "Expected 'True' but got 'False'",
             "name": "2400 - year divisible by 400 but not by 125 is still a leap year",
-            "status": "fail"
+            "status": "fail",
+            "task_id": null
         },
         {
             "message": null,
             "name": "1800 - year divisible by 200, not divisible by 400 in common year",
-            "status": "pass"
+            "status": "pass",
+            "task_id": null
         }
     ],
     "version": 2

--- a/tests/example-success/.exercism/metadata.json
+++ b/tests/example-success/.exercism/metadata.json
@@ -1,0 +1,13 @@
+{
+  "tests": {
+    "2015 - year not divisible by 4 in common year": { "task_id": 1 },
+    "1970 - year divisible by 2, not divisible by 4 in common year": { "task_id": 1 },
+    "1996 - year divisible by 4, not divisible by 100 in leap year": { "task_id": 1 },
+    "1960 - year divisible by 4 and 5 is still a leap year": { "task_id": 1 },
+    "2100 - year divisible by 100, not divisible by 400 in common year": { "task_id": 1 },
+    "1900 - year divisible by 100 but not by 3 is still not a leap year": { "task_id": 1 },
+    "2000 - year divisible by 400 in leap year": { "task_id": 1 },
+    "2400 - year divisible by 400 but not by 125 is still a leap year": { "task_id": 1 },
+    "1800 - year divisible by 200, not divisible by 400 in common year": { "task_id": 1 }
+  }
+}

--- a/tests/example-success/expected_results.json
+++ b/tests/example-success/expected_results.json
@@ -5,47 +5,56 @@
         {
             "message": null,
             "name": "2015 - year not divisible by 4 in common year",
-            "status": "pass"
+            "status": "pass",
+            "task_id": 1
         },
         {
             "message": null,
             "name": "1970 - year divisible by 2, not divisible by 4 in common year",
-            "status": "pass"
+            "status": "pass",
+            "task_id": 1
         },
         {
             "message": null,
             "name": "1996 - year divisible by 4, not divisible by 100 in leap year",
-            "status": "pass"
+            "status": "pass",
+            "task_id": 1
         },
         {
             "message": null,
             "name": "1960 - year divisible by 4 and 5 is still a leap year",
-            "status": "pass"
+            "status": "pass",
+            "task_id": 1
         },
         {
             "message": null,
             "name": "2100 - year divisible by 100, not divisible by 400 in common year",
-            "status": "pass"
+            "status": "pass",
+            "task_id": 1
         },
         {
             "message": null,
             "name": "1900 - year divisible by 100 but not by 3 is still not a leap year",
-            "status": "pass"
+            "status": "pass",
+            "task_id": 1
         },
         {
             "message": null,
             "name": "2000 - year divisible by 400 in leap year",
-            "status": "pass"
+            "status": "pass",
+            "task_id": 1
         },
         {
             "message": null,
             "name": "2400 - year divisible by 400 but not by 125 is still a leap year",
-            "status": "pass"
+            "status": "pass",
+            "task_id": 1
         },
         {
             "message": null,
             "name": "1800 - year divisible by 200, not divisible by 400 in common year",
-            "status": "pass"
+            "status": "pass",
+            "task_id": 1
         }
     ],
     "version": 2

--- a/tests/example-syntax-error/expected_results.json
+++ b/tests/example-syntax-error/expected_results.json
@@ -1,5 +1,5 @@
 {
   "version": 2,
   "status": "error",
-  "message": "\n/solution/src/LeapYear.hs:1:7: error: parse error on input ‘@#^&@#’\n  |\n1 | module@#^&@# LeapYear2341\n  |       ^^^^^^\n\nError: [S-7282]\n       Stack failed to execute the build plan.\n       \n       While executing the build plan, Stack encountered the following errors:\n       \n       [S-7011]\n       While building package leap-1.6.0.10 (scroll up to its section to see the error) using:\n       --verbose=1 build lib:leap test:test --ghc-options \"\"\n       Process exited with code: ExitFailure 1 "
+  "message": "\n/solution/src/LeapYear.hs:1:7: error: parse error on input ‘@#^&@#’\n  |\n1 | module@#^&@# LeapYear2341\n  |       ^^^^^^\n\nError: [S-7282]\n       Stack failed to execute the build plan.\n       \n       While executing the build plan, Stack encountered the error:\n       \n       [S-7011]\n       While building package leap-1.6.0.10 (scroll up to its section to see the error) using:\n       --verbose=1 build lib:leap test:test --ghc-options \"\"\n       Process exited with code: ExitFailure 1 "
 }


### PR DESCRIPTION
This is an initial stab at #19. It looks for a name to task id mapping in the projects manifest file `metadata.json`. For instance for `leap` the root object should be amended with an object like this:

```
  "tests": {
    "2015 - year not divisible by 4 in common year": { "task_id": 1 },
    "1970 - year divisible by 2, not divisible by 4 in common year": { "task_id": 1 },
    "1996 - year divisible by 4, not divisible by 100 in leap year": { "task_id": 1 },
    "1960 - year divisible by 4 and 5 is still a leap year": { "task_id": 1 },
    "2100 - year divisible by 100, not divisible by 400 in common year": { "task_id": 1 },
    "1900 - year divisible by 100 but not by 3 is still not a leap year": { "task_id": 1 },
    "2000 - year divisible by 400 in leap year": { "task_id": 1 },
    "2400 - year divisible by 400 but not by 125 is still a leap year": { "task_id": 1 },
    "1800 - year divisible by 200, not divisible by 400 in common year": { "task_id": 1 }
  }
```

Or whatever the task id is supposed to be. This wasn't entirely clear to me.

I've added a module `Manifest.hs` that will look for `metadata.json`. The mechanism used for locating the file simply assumes that the `cwd` is where `.exercism` is located. This might not be the most robust way to do it, but it *is* what the test runner seems to do. So I don't see any immediate benefit to improving this. If `metadata.json` is not located or fails to parse the task IDs are simply set to `null` in the generated report.

Here is an example of how the output report changes with this patch for the `leap` task if you were to add an appropriate section in `metadata.json`:

```diff
 {
     "message": null,
     "status": "fail",
     "tests": [
         {
             "message": null,
             "name": "2015 - year not divisible by 4 in common year",
-            "status": "pass"
+            "status": "pass",
+            "task_id": null
         },
         {
             "message": null,
             "name": "1970 - year divisible by 2, not divisible by 4 in common year",
-            "status": "pass"
+            "status": "pass",
+            "task_id": null
         },
...
```

I've updated the tests. I had one issue with the tests where the GHC/Stack output seems to have changed wording subtly according to:

```diff
-Stack encountered the following errors:
+Stack encountered the error:
```

I had to add this change to get the tests to work with my local setup, though I appreciate we might need to not include it in the patch or do something else to accommodate the discrepancy.