### PR TITLE
Parse YAML before working on it

### DIFF
--- a/test-setup/package.yaml
+++ b/test-setup/package.yaml
@@ -10,4 +10,8 @@ executables:
     source-dirs: src
     ghc-options: -Wall
     dependencies:
+      - aeson
       - directory
+      - lens
+      - lens-aeson
+      - yaml


### PR DESCRIPTION
Previously the list of `test` dependencies was extended through appending onto the containing file. This approach was fragile: exercism/haskell#1212, exercism/haskell#1241.

This patch avoids subsequent parsing problems by itself parsing the YAML before extending the list.