### PR TITLE
github: change the CODEOWNERS from @exercism/maintainers-admin to @exercism/guardians

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,2 @@
-* @exercism/maintainers-admin
-pre-compiled/package.yaml @exercism/haskell @exercism/maintainers-admin
+* @exercism/guardians
+pre-compiled/package.yaml @exercism/haskell @exercism/guardians


### PR DESCRIPTION
This PR changes the CODEOWNERS from @exercism/maintainers-admin to @exercism/guardians.

This allows us to have a separate team of trusted polyglots, responsible for checking for security issues.