### PR TITLE
Update Haskell to 9.6.7 on Debian 12 (bookworm) with resolver lts-22.44

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,9 +1,9 @@
-.git/
-.github/
-.stack-work/
-tests/
 .appends
-.gitignore
-.gitattributes
 .dockerignore
+.git/
+.gitattributes
+.github/
+.gitignore
+.stack-work/
 Dockerfile
+tests/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,19 +1,18 @@
-ARG HASKELL_VERSION=9.10.3
+ARG HASKELL_VERSION=9.6.7
 FROM haskell:${HASKELL_VERSION}-slim-bookworm@sha256:0a066cefb7fa9723242540b141242db9db7a1609131ead85313802ea62d35e20
 
 RUN apt-get update && apt-get install --yes --no-install-recommends jq && rm -rf /var/lib/apt/lists/*
 
 # Set up the environment
-ARG HASKELL_VERSION=9.10.3
+ARG HASKELL_VERSION=9.6.7
 ENV STACK_ROOT=/opt/test-runner/.stack
 ENV LANG=C.UTF-8
 ENV PATH=/root/.cabal/bin:/root/.local/bin:/opt/ghc/${HASKELL_VERSION}/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
-ENV STACK_ROOT=/opt/test-runner/.stack
 
 WORKDIR /opt/test-runner/
 
 COPY pre-compiled/ .
-RUN stack build --resolver lts-24.39 --no-terminal --test --no-run-tests
+RUN stack build --resolver lts-22.44 --no-terminal --test --no-run-tests
 
 COPY . .
 RUN cd ./test-setup/ && stack build setup-tests --copy-bins --local-bin-path /opt/test-runner/bin/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,21 +1,21 @@
-FROM haskell:9.2.7-slim-buster
+ARG HASKELL_VERSION=9.10.3
+FROM haskell:${HASKELL_VERSION}-slim-bookworm@sha256:0a066cefb7fa9723242540b141242db9db7a1609131ead85313802ea62d35e20
 
-RUN apt-get update && \
-    apt-get install -y jq && \
-    apt-get purge --auto-remove && \
-    apt-get clean && \
-    rm -rf /var/lib/apt/lists/*
+RUN apt-get update && apt-get install --yes --no-install-recommends jq && rm -rf /var/lib/apt/lists/*
 
+# Set up the environment
+ARG HASKELL_VERSION=9.10.3
+ENV STACK_ROOT=/opt/test-runner/.stack
+ENV LANG=C.UTF-8
+ENV PATH=/root/.cabal/bin:/root/.local/bin:/opt/ghc/${HASKELL_VERSION}/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
 ENV STACK_ROOT=/opt/test-runner/.stack
 
 WORKDIR /opt/test-runner/
 
 COPY pre-compiled/ .
-RUN stack build --resolver lts-20.18 --no-terminal --test --no-run-tests
+RUN stack build --resolver lts-24.39 --no-terminal --test --no-run-tests
 
 COPY . .
-
-RUN cd ./test-setup/ && stack build setup-tests --copy-bins --local-bin-path /opt/test-runner/bin/ && cd ..
+RUN cd ./test-setup/ && stack build setup-tests --copy-bins --local-bin-path /opt/test-runner/bin/
 
 ENTRYPOINT ["/opt/test-runner/bin/run.sh"]
-

--- a/bin/run-in-docker.sh
+++ b/bin/run-in-docker.sh
@@ -34,7 +34,12 @@ mkdir -p "${output_dir}"
 docker build --rm -t exercism/haskell-test-runner .
 
 # Run the Docker image using the settings mimicking the production environment
-# TODO: --read-only
+# `run.sh` needs to modify/set up the source directory.
+# * Modify the /solution directly then restore state, which is a bit messy and resets write timestamps.
+# * Copy /solution to /tmp and run the solution from a tmpdir.
+#   * A `test` executable is written inside the solution dir. If we use a tmpfs, Docker mounts it with noexec.
+#   * We can skip a tmpfs and use /tmp, but then we cannot use --readonly.
+# * Copy /solution to /tmp, modify /solution then restore from the backup in /tmp.
 docker run \
     --rm \
     --network none \

--- a/bin/run-tests.sh
+++ b/bin/run-tests.sh
@@ -15,40 +15,36 @@ set -euo pipefail
 
 exit_code=0
 
+# Delete existing results files
+find tests -name results.json -delete
 # Iterate over all test directories
 for test_dir in tests/*; do
     test_dir_name=$(basename "${test_dir}")
     test_dir_path=$(realpath "${test_dir}")
     results_file_path="${test_dir_path}/results.json"
     expected_results_file_path="${test_dir_path}/expected_results.json"
-    stack_root=$(stack --resolver lts-20.18 path --stack-root)
+    stack_root=$(stack --resolver lts-24.39 path --stack-root)
 
     bin/run.sh "${test_dir_name}" "${test_dir_path}" "${test_dir_path}"
 
-    # Normalize the results file
-    sed -i -E \
-      -e 's/Randomized with seed [0-9]+\\n//' \
-      -e 's/Finished in [0-9]+\.[0-9]+ seconds\\n//' \
-      -e 's/Completed [0-9]+ action\(s\).\\n//' \
-      -e "s~${test_dir_path}~/solution~g" \
-      -e 's/--builddir[^ ]+ //' \
-      -e "s~${stack_root}/[^ ]+ ~~g" \
-      "${results_file_path}"
-
-    # disable -e since we want all diffs even if one has unexpected
-    # results
-    old_opts=$-
-    set +e
-
-    echo "${test_dir_name}: comparing results.json to expected_results.json"
-    diff "${results_file_path}" "${expected_results_file_path}"
-
-    if [ $? -ne 0 ]; then
-        exit_code=1
+    # Normalize the message in the results file
+    if jq -e '.message != null' "${results_file_path}" > /dev/null; then
+        message=$(
+            jq -r .message "${results_file_path}" \
+            | sed "
+                1,1 {
+                    s@${test_dir_path}@/solution@
+                    s/error: .*/error/
+                }
+                s@/opt/test-runner/.*ghc-9.10.3 @@"
+        )
+        jq --arg m "${message}" '.message = $m' "${results_file_path}" > "${results_file_path}.updated"
+        mv "${results_file_path}.updated" "${results_file_path}"
     fi
 
-    # re-enable original options
-    set -$old_opts
+    # Compare results
+    echo "${test_dir_name}: comparing results.json to expected_results.json"
+    diff "${results_file_path}" "${expected_results_file_path}" || exit_code=1
 done
 
-exit ${exit_code}
+exit "${exit_code}"

--- a/bin/run-tests.sh
+++ b/bin/run-tests.sh
@@ -23,7 +23,7 @@ for test_dir in tests/*; do
     test_dir_path=$(realpath "${test_dir}")
     results_file_path="${test_dir_path}/results.json"
     expected_results_file_path="${test_dir_path}/expected_results.json"
-    stack_root=$(stack --resolver lts-24.39 path --stack-root)
+    stack_root=$(stack --resolver lts-22.44 path --stack-root)
 
     bin/run.sh "${test_dir_name}" "${test_dir_path}" "${test_dir_path}"
 
@@ -32,11 +32,12 @@ for test_dir in tests/*; do
         message=$(
             jq -r .message "${results_file_path}" \
             | sed "
-                1,1 {
+		1d
+                2 {
                     s@${test_dir_path}@/solution@
                     s/error: .*/error/
                 }
-                s@/opt/test-runner/.*ghc-9.10.3 @@"
+                s@/opt/test-runner/.*ghc-9.6.7 @@"
         )
         jq --arg m "${message}" '.message = $m' "${results_file_path}" > "${results_file_path}.updated"
         mv "${results_file_path}.updated" "${results_file_path}"

--- a/bin/run.sh
+++ b/bin/run.sh
@@ -15,6 +15,8 @@
 # Example:
 # ./bin/run.sh two-fer /absolute/path/to/two-fer/solution/folder/ /absolute/path/to/output/directory/
 
+resolver=lts-24.39
+
 set -euo pipefail
 
 # If any required arguments is missing, print the usage and exit
@@ -26,78 +28,71 @@ fi
 slug="$1"
 input_dir="${2%/}"
 output_dir="${3%/}"
-results_file="${output_dir}/results.json"
 setup_tests_executable="bin/setup-tests"
+tmp=$(mktemp -d)
+trap 'rm -rf "${tmp}"' EXIT
+
+# Back up the input directory to restore later.
+cp -Rp "${input_dir}" "${tmp}"
 
 # Create the output directory if it doesn't exist
 mkdir -p "${output_dir}"
 
 echo "${slug}: testing..."
 
-stack_yml_file_contents=$(< "${input_dir}/stack.yaml")
-package_yml_file_contents=$(< "${input_dir}/package.yaml")
-tests_file_contents=$(< "${input_dir}/test/Tests.hs")
-
-echo "system-ghc: true" >> "${input_dir}/stack.yaml"
+{
+    echo "resolver: ${resolver}"
+    echo "system-ghc: true"
+} > "${input_dir}/stack.yaml"
 
 # Run our test setup which does some code injection to modify how the tests
 # will run to use our custom hspec formatter that outputs results.json automatically.
 # We expect the setup-tests executable to be pre-built in Docker, but fallback to using runghc in case it isn't
 # found so that developers can continue to easily run `bin/run.sh` locally.
-if [ -f "${setup_tests_executable}" ]; then
-  ${setup_tests_executable} "${input_dir}"
+if [ -x "${setup_tests_executable}" ]; then
+    "${setup_tests_executable}" "${input_dir}"
 else
-  echo "Did not find bin/setup-tests executable - using stack runghc ./test-setup/src/Main.hs instead"
-  stack --resolver lts-20.18 runghc ./test-setup/src/Main.hs "$input_dir"
+    echo "Did not find bin/setup-tests executable - using stack runghc ./test-setup/src/Main.hs instead"
+    stack --resolver "${resolver}" runghc ./test-setup/src/Main.hs "${input_dir}"
 fi
 
-pushd "${input_dir}" > /dev/null
-
-# disable -e since we expect some tests to fail
-old_opts=$-
-set +e
+cd "${input_dir}"
 
 # Run the tests for the provided implementation file and redirect stdout and
-# stderr to capture it
-test_output=$(stack build --resolver lts-20.18 --test --allow-different-user 2>&1)
+# stderr to capture it.
+# Use cmd || true to avoid exiting if tests fail (set -e).
+test_output=$(stack build --resolver "${resolver}" --test --allow-different-user 2>&1) || true
 
 # Copy results.json to the output directory (only if output directory is different from
-# the input directory)
-if [ "${input_dir}/results.json" != "${results_file}" ]; then
-  mv "${input_dir}/results.json" "${results_file}"
+# the input directory).
+# This file may not exist if the test failed to run, eg on a compiler error.
+if [ "${output_dir}" != "${input_dir}" ] && [ -e "${input_dir}/results.json" ]; then
+    mv "${input_dir}/results.json" "${output_dir}/results.json"
 fi
-
-# re-enable original options
-set -$old_opts
-
-# Remove the .stack-work directory, as its 40MB+ size fills up the test runner's disk
-rm -rf .stack-work 
-
-popd
 
 # If the results.json file does not exist, it means that the tests failed to run
 # (usually this would be a compiler error)
+results_file="${output_dir}/results.json"
 if ! [ -f "${results_file}" ]; then
     # Sanitize the output
     if grep -q "Registering library for " <<< "${test_output}" ; then
-	sanitized_test_output=$(printf "%s" "${test_output}" | sed -n -E -e '1,/^Registering library for/!p')
-    elif grep -q "Building library for " <<< "${test_output}" ; then
-	sanitized_test_output=$(printf "%s" "${test_output}" | sed -n -E -e '1,/^Building library for/!p')
-    else
-	sanitized_test_output="${test_output}"
+        test_output=$(sed -n -E -e '1,/^Registering library for/!p' <<< "${test_output}")
+    fi
+    if grep -q "Building library for " <<< "${test_output}" ; then
+        test_output=$(sed -n -E -e '1,/^Building library for/!p' <<< "${test_output}")
     fi
 
-    # Manually add colors to the output to help scanning the output for errors
-    colorized_test_output=$(echo "${sanitized_test_output}" \
-	| GREP_COLOR='01;31' grep --color=always -E -e '.*FAILED \[[0-9]+\]$|$')
-
-    jq -n --arg output "${colorized_test_output}" '{version: 2, status: "error", message: $output}' > "${results_file}"
+    jq -n --arg output "${test_output}" '{version: 2, status: "error", message: $output}' > "${results_file}"
 fi
 
-# Revert input directory code to it's initial state
-echo "$stack_yml_file_contents" > "${input_dir}/stack.yaml"
-echo "$package_yml_file_contents" > "${input_dir}/package.yaml"
-echo "$tests_file_contents" > "${input_dir}/test/Tests.hs"
-rm -f "${input_dir}/test/HspecFormatter.hs"
+# Restore state
+for file in 'stack.yaml' 'package.yaml' 'test/Tests.hs'; do
+    cat "${tmp}/${input_dir##*/}/${file}" > "${input_dir}/${file}"
+done
+for file in 'test/HspecFormatter.hs' '.stack-work' "${slug}.cabal"; do
+    rm -rf "${input_dir}/${file}"
+done
+# Drop the tmp dir
+rm -rf "${tmp}"
 
 echo "${slug}: done"

--- a/bin/run.sh
+++ b/bin/run.sh
@@ -15,7 +15,7 @@
 # Example:
 # ./bin/run.sh two-fer /absolute/path/to/two-fer/solution/folder/ /absolute/path/to/output/directory/
 
-resolver=lts-24.39
+resolver=lts-22.44
 
 set -euo pipefail
 

--- a/pre-compiled/stack.yaml
+++ b/pre-compiled/stack.yaml
@@ -1,3 +1,3 @@
 system-ghc: true
 
-resolver: lts-20.18
+resolver: lts-24.39

--- a/pre-compiled/stack.yaml
+++ b/pre-compiled/stack.yaml
@@ -1,3 +1,3 @@
 system-ghc: true
 
-resolver: lts-24.39
+resolver: lts-22.44

--- a/test-setup/stack.yaml
+++ b/test-setup/stack.yaml
@@ -1,3 +1,3 @@
 system-ghc: true
 
-resolver: lts-20.18
+resolver: lts-24.39

--- a/test-setup/stack.yaml
+++ b/test-setup/stack.yaml
@@ -1,3 +1,3 @@
 system-ghc: true
 
-resolver: lts-24.39
+resolver: lts-22.44

--- a/tests/example-all-fail/stack.yaml
+++ b/tests/example-all-fail/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-20.18
+resolver: lts-24.39

--- a/tests/example-all-fail/stack.yaml
+++ b/tests/example-all-fail/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-24.39
+resolver: lts-22.44

--- a/tests/example-empty-file/expected_results.json
+++ b/tests/example-empty-file/expected_results.json
@@ -1,5 +1,5 @@
 {
   "version": 2,
   "status": "error",
-  "message": "/solution/src/LeapYear.hs:1:1: error\n    File name does not match module name:\n    Saw     : ‘Main’\n    Expected: ‘LeapYear’\n\n\nError: [S-7282]\n       Stack failed to execute the build plan.\n       \n       While executing the build plan, Stack encountered the error:\n       \n       [S-7011]\n       While building package leap-1.6.0.10 (scroll up to its section to see the error) using:\n       build lib:leap test:test --ghc-options \"\"\n       Process exited with code: ExitFailure 1 "
+  "message": "/solution/src/LeapYear.hs:1:1: error\n    File name does not match module name:\n    Saw     : ‘Main’\n    Expected: ‘LeapYear’\n\nError: [S-7282]\n       Stack failed to execute the build plan.\n       \n       While executing the build plan, Stack encountered the error:\n       \n       [S-7011]\n       While building package leap-1.6.0.10 (scroll up to its section to see the error) using:\n       build lib:leap test:test --ghc-options \"\"\n       Process exited with code: ExitFailure 1 "
 }

--- a/tests/example-empty-file/expected_results.json
+++ b/tests/example-empty-file/expected_results.json
@@ -1,5 +1,5 @@
 {
   "version": 2,
   "status": "error",
-  "message": "\n/solution/src/LeapYear.hs:1:1: error:\n    File name does not match module name:\n    Saw: ‘Main’\n    Expected: ‘LeapYear’\n\nError: [S-7282]\n       Stack failed to execute the build plan.\n       \n       While executing the build plan, Stack encountered the following errors:\n       \n       [S-7011]\n       While building package leap-1.6.0.10 (scroll up to its section to see the error) using:\n       --verbose=1 build lib:leap test:test --ghc-options \"\"\n       Process exited with code: ExitFailure 1 "
+  "message": "/solution/src/LeapYear.hs:1:1: error\n    File name does not match module name:\n    Saw     : ‘Main’\n    Expected: ‘LeapYear’\n\n\nError: [S-7282]\n       Stack failed to execute the build plan.\n       \n       While executing the build plan, Stack encountered the error:\n       \n       [S-7011]\n       While building package leap-1.6.0.10 (scroll up to its section to see the error) using:\n       build lib:leap test:test --ghc-options \"\"\n       Process exited with code: ExitFailure 1 "
 }

--- a/tests/example-empty-file/stack.yaml
+++ b/tests/example-empty-file/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-20.18
+resolver: lts-24.39

--- a/tests/example-empty-file/stack.yaml
+++ b/tests/example-empty-file/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-24.39
+resolver: lts-22.44

--- a/tests/example-partial-fail/stack.yaml
+++ b/tests/example-partial-fail/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-20.18
+resolver: lts-24.39

--- a/tests/example-partial-fail/stack.yaml
+++ b/tests/example-partial-fail/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-24.39
+resolver: lts-22.44

--- a/tests/example-success/stack.yaml
+++ b/tests/example-success/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-20.18
+resolver: lts-24.39

--- a/tests/example-success/stack.yaml
+++ b/tests/example-success/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-24.39
+resolver: lts-22.44

--- a/tests/example-syntax-error/expected_results.json
+++ b/tests/example-syntax-error/expected_results.json
@@ -1,5 +1,5 @@
 {
   "version": 2,
   "status": "error",
-  "message": "\n/solution/src/LeapYear.hs:1:7: error: parse error on input ‘@#^&@#’\n  |\n1 | module@#^&@# LeapYear2341\n  |       ^^^^^^\n\nError: [S-7282]\n       Stack failed to execute the build plan.\n       \n       While executing the build plan, Stack encountered the following errors:\n       \n       [S-7011]\n       While building package leap-1.6.0.10 (scroll up to its section to see the error) using:\n       --verbose=1 build lib:leap test:test --ghc-options \"\"\n       Process exited with code: ExitFailure 1 "
+  "message": "/solution/src/LeapYear.hs:1:7: error\n    parse error on input ‘@#^&@#’\n  |\n1 | module@#^&@# LeapYear2341\n  |       ^^^^^^\n\n\nError: [S-7282]\n       Stack failed to execute the build plan.\n       \n       While executing the build plan, Stack encountered the error:\n       \n       [S-7011]\n       While building package leap-1.6.0.10 (scroll up to its section to see the error) using:\n       build lib:leap test:test --ghc-options \"\"\n       Process exited with code: ExitFailure 1 "
 }

--- a/tests/example-syntax-error/expected_results.json
+++ b/tests/example-syntax-error/expected_results.json
@@ -1,5 +1,5 @@
 {
   "version": 2,
   "status": "error",
-  "message": "/solution/src/LeapYear.hs:1:7: error\n    parse error on input ‘@#^&@#’\n  |\n1 | module@#^&@# LeapYear2341\n  |       ^^^^^^\n\n\nError: [S-7282]\n       Stack failed to execute the build plan.\n       \n       While executing the build plan, Stack encountered the error:\n       \n       [S-7011]\n       While building package leap-1.6.0.10 (scroll up to its section to see the error) using:\n       build lib:leap test:test --ghc-options \"\"\n       Process exited with code: ExitFailure 1 "
+  "message": "/solution/src/LeapYear.hs:1:7: error\n    parse error on input ‘@#^&@#’\n  |\n1 | module@#^&@# LeapYear2341\n  |       ^^^^^^\n\nError: [S-7282]\n       Stack failed to execute the build plan.\n       \n       While executing the build plan, Stack encountered the error:\n       \n       [S-7011]\n       While building package leap-1.6.0.10 (scroll up to its section to see the error) using:\n       build lib:leap test:test --ghc-options \"\"\n       Process exited with code: ExitFailure 1 "
 }

--- a/tests/example-syntax-error/stack.yaml
+++ b/tests/example-syntax-error/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-20.18
+resolver: lts-24.39

--- a/tests/example-syntax-error/stack.yaml
+++ b/tests/example-syntax-error/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-24.39
+resolver: lts-22.44


### PR DESCRIPTION
New image size: 3.83GB

* Upgrade the base layer and versions.
  * The layer uses haskell:${HASKELL_VERSION}-slim-bookworm
  * Haskell is updated 9.2.7 -> 9.10.3
  * Debian is updated slim-buster (no longer supported) -> slim-bookworm
  * Update resolver lts-20.18 -> 24.39
* Sort the contents of .dockerignore
* `run-tests.sh` is updated to clean up the shell code.
  * Rewrite the message normalizer.
* `run.sh` uses a tmpdir to backup then restore the solution files.
* Expected test output is updated to match the latest output.