### PR TITLE
Use a `/tmp` volume for the solution workspace.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,9 @@ WORKDIR /opt/test-runner/
 COPY pre-compiled/ .
 RUN stack build --resolver lts-22.44 --no-terminal --test --no-run-tests
 
+COPY ./test-setup/ /opt/test-runner/test-setup/
+RUN mkdir /opt/test-runner/bin/ && cd /opt/test-runner/test-setup/ && stack build setup-tests --copy-bins --local-bin-path /opt/test-runner/bin/
+
 COPY . .
-RUN cd ./test-setup/ && stack build setup-tests --copy-bins --local-bin-path /opt/test-runner/bin/
 
 ENTRYPOINT ["/opt/test-runner/bin/run.sh"]

--- a/bin/run-in-docker.sh
+++ b/bin/run-in-docker.sh
@@ -33,17 +33,15 @@ mkdir -p "${output_dir}"
 # Build the Docker image
 docker build --rm -t exercism/haskell-test-runner .
 
-# Run the Docker image using the settings mimicking the production environment
-# `run.sh` needs to modify/set up the source directory.
-# * Modify the /solution directly then restore state, which is a bit messy and resets write timestamps.
-# * Copy /solution to /tmp and run the solution from a tmpdir.
-#   * A `test` executable is written inside the solution dir. If we use a tmpfs, Docker mounts it with noexec.
-#   * We can skip a tmpfs and use /tmp, but then we cannot use --readonly.
-# * Copy /solution to /tmp, modify /solution then restore from the backup in /tmp.
+# Run the Docker image using the settings mimicking the production environment.
+# `run.sh` modifies the solution files then generates and runs an executable.
+# This requires a temp location (to avoid dirtying host files) with exec settings (to run it).
+# type=tmpfs gives us a mount with noexec set.
+# type=volume gives us an anonymous volume; --rm cleans it up later.
 docker run \
     --rm \
     --network none \
     --mount type=bind,src="${input_dir}",dst=/solution \
     --mount type=bind,src="${output_dir}",dst=/output \
-    --mount type=tmpfs,dst=/tmp \
+    --mount type=volume,dst=/tmp \
     exercism/haskell-test-runner "${slug}" /solution /output 

--- a/bin/run-tests-in-docker.sh
+++ b/bin/run-tests-in-docker.sh
@@ -17,12 +17,11 @@ set -e
 docker build --rm -t exercism/haskell-test-runner .
 
 # Run the Docker image using the settings mimicking the production environment
-# TODO: --read-only
 docker run \
     --rm \
     --network none \
     --mount type=bind,src="${PWD}/tests",dst=/opt/test-runner/tests \
-    --mount type=tmpfs,dst=/tmp \
+    --mount type=volume,dst=/tmp \
     --workdir /opt/test-runner \
     --entrypoint /opt/test-runner/bin/run-tests.sh \
     exercism/haskell-test-runner

--- a/bin/run-tests.sh
+++ b/bin/run-tests.sh
@@ -34,7 +34,7 @@ for test_dir in tests/*; do
             | sed "
 		1d
                 2 {
-                    s@${test_dir_path}@/solution@
+                    s@/tmp/.*/${test_dir_name}/@/solution/@
                     s/error: .*/error/
                 }
                 s@/opt/test-runner/.*ghc-9.6.7 @@"

--- a/bin/run.sh
+++ b/bin/run.sh
@@ -20,7 +20,7 @@ resolver=lts-22.44
 set -euo pipefail
 
 # If any required arguments is missing, print the usage and exit
-if [ -z "$1" ] || [ -z "$2" ] || [ -z "$3" ]; then
+if [[ -z "$1" || -z "$2" || -z "$3" ]]; then
     echo "usage: ./bin/run.sh exercise-slug /absolute/path/to/two-fer/solution/folder/ /absolute/path/to/output/directory/"
     exit 1
 fi
@@ -32,8 +32,9 @@ setup_tests_executable="bin/setup-tests"
 tmp=$(mktemp -d)
 trap 'rm -rf "${tmp}"' EXIT
 
-# Back up the input directory to restore later.
-cp -Rp "${input_dir}" "${tmp}"
+# Copy the solution to tmp so we can modify files without modifying the host data.
+cp -R "${input_dir}" "${tmp}"
+solution="${tmp}/${input_dir##*/}"
 
 # Create the output directory if it doesn't exist
 mkdir -p "${output_dir}"
@@ -43,37 +44,36 @@ echo "${slug}: testing..."
 {
     echo "resolver: ${resolver}"
     echo "system-ghc: true"
-} > "${input_dir}/stack.yaml"
+} > "${solution}/stack.yaml"
 
 # Run our test setup which does some code injection to modify how the tests
 # will run to use our custom hspec formatter that outputs results.json automatically.
 # We expect the setup-tests executable to be pre-built in Docker, but fallback to using runghc in case it isn't
 # found so that developers can continue to easily run `bin/run.sh` locally.
-if [ -x "${setup_tests_executable}" ]; then
-    "${setup_tests_executable}" "${input_dir}"
+if [[ -x "${setup_tests_executable}" ]]; then
+    "${setup_tests_executable}" "${solution}"
 else
     echo "Did not find bin/setup-tests executable - using stack runghc ./test-setup/src/Main.hs instead"
-    stack --resolver "${resolver}" runghc ./test-setup/src/Main.hs "${input_dir}"
+    stack --resolver "${resolver}" runghc ./test-setup/src/Main.hs "${solution}"
 fi
 
-cd "${input_dir}"
+cd "${solution}"
 
 # Run the tests for the provided implementation file and redirect stdout and
 # stderr to capture it.
 # Use cmd || true to avoid exiting if tests fail (set -e).
 test_output=$(stack build --resolver "${resolver}" --test --allow-different-user 2>&1) || true
 
-# Copy results.json to the output directory (only if output directory is different from
-# the input directory).
+# Copy results.json to the output directory.
 # This file may not exist if the test failed to run, eg on a compiler error.
-if [ "${output_dir}" != "${input_dir}" ] && [ -e "${input_dir}/results.json" ]; then
-    mv "${input_dir}/results.json" "${output_dir}/results.json"
+if [[ -e "${solution}/results.json" ]]; then
+    mv "${solution}/results.json" "${output_dir}/results.json"
 fi
 
 # If the results.json file does not exist, it means that the tests failed to run
 # (usually this would be a compiler error)
 results_file="${output_dir}/results.json"
-if ! [ -f "${results_file}" ]; then
+if ! [[ -f "${results_file}" ]]; then
     # Sanitize the output
     if grep -q "Registering library for " <<< "${test_output}" ; then
         test_output=$(sed -n -E -e '1,/^Registering library for/!p' <<< "${test_output}")
@@ -85,13 +85,6 @@ if ! [ -f "${results_file}" ]; then
     jq -n --arg output "${test_output}" '{version: 2, status: "error", message: $output}' > "${results_file}"
 fi
 
-# Restore state
-for file in 'stack.yaml' 'package.yaml' 'test/Tests.hs'; do
-    cat "${tmp}/${input_dir##*/}/${file}" > "${input_dir}/${file}"
-done
-for file in 'test/HspecFormatter.hs' '.stack-work' "${slug}.cabal"; do
-    rm -rf "${input_dir}/${file}"
-done
 # Drop the tmp dir
 rm -rf "${tmp}"
 


### PR DESCRIPTION
The test runner modifies and writes a bunch of files in the solution directory. When done directly in the mounted path, this can leave root-owned files (newly created) and leave changes to the original files. By copying to a temp directory and working there, the original path is left clean ... and no cleanup handling is needed. `type=volume` is needed to get an executable mount (opposed to `tmpfs` which gives `noexec`).

Additional changes:

* Copy the `bin/run*.sh` scripts to Docker after running `stack build setup-tests`. This prevents needing to rerun the build command on shell script changes.
* `run.sh` uses bash; update the tests to bash's `[[`.